### PR TITLE
Warn on yamllint line length errors

### DIFF
--- a/yamllint.yml
+++ b/yamllint.yml
@@ -2,7 +2,8 @@ extends: default
 
 rules:
   line-length:
-    level: error
+    max: 120
+    level: warning
   document-start:
     present: false
     level: error


### PR DESCRIPTION
Potentially controversial change :)

The OASIS [meta_standards](https://github.com/oasis-roles/meta_standards) don't recommend a line length restriction for yaml files, and more often than not I find the line length restriction only causes me to make my yaml files *less* readable. I think that the line length restriction can be turned into a warning, and warnings should still be issued in cases where the line length becomes eyebrow-raisingly long (arbitrarily decided in this PR to be 120 chars).