### PR TITLE
Fix for new ansible-lint error for role names

### DIFF
--- a/ansible-lint
+++ b/ansible-lint
@@ -1,2 +1,3 @@
 skip_list:
   - "204"
+  - role-name


### PR DESCRIPTION
At some point a 'role-name' rule  [1] was introduced, and our naming
convention is not compatible.  I'm adding an ingore statement for this
rule unless we intend on changing all of our role names, which seems
difficult.  The following failure will occur on many of our roles if we
do not ignore it:

```
ansible-lint WARNING  Listing 1 violation(s) that are fatal
role-name: Role name  does not match ^[a-z][a-z0-9_]+$ pattern
```

[1] https://ansible-lint.readthedocs.io/en/latest/default_rules.html#role-name